### PR TITLE
Player Movement Scripts are now singletons

### DIFF
--- a/Assets/IObserver.cs
+++ b/Assets/IObserver.cs
@@ -1,0 +1,5 @@
+public interface IObserver
+{
+	//Cant be called just update because Unity has a function called update
+	void UpdateWhenNotified();
+}

--- a/Assets/IObserver.cs.meta
+++ b/Assets/IObserver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 446635ce943a6cf48a98bde10ae784fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Movement/Climbing.cs
+++ b/Assets/Movement/Climbing.cs
@@ -44,6 +44,20 @@ public class Climbing : MonoBehaviour
 	public float exitWallTime;
 	private float exitWallTimer;
 
+	private static Climbing instance;
+
+	public static Climbing Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new Climbing();
+			}
+			return instance;
+		}
+	}
+
 	private void Start()
 	{
 		lg = GetComponent<LedgeGrabbing>();	

--- a/Assets/Movement/Climbing.cs
+++ b/Assets/Movement/Climbing.cs
@@ -2,8 +2,20 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Climbing : MonoBehaviour
+public class Climbing : MonoBehaviour, IObserver
 {
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
 	[Header("References")]
 	public Transform orientation;
 	public Rigidbody rb;
@@ -60,7 +72,12 @@ public class Climbing : MonoBehaviour
 
 	private void Start()
 	{
-		lg = GetComponent<LedgeGrabbing>();	
+		lg = GetComponent<LedgeGrabbing>();
+
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
 	}
 
 	private void Update()

--- a/Assets/Movement/Climbing.cs
+++ b/Assets/Movement/Climbing.cs
@@ -2,20 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Climbing : MonoBehaviour, IObserver
+public class Climbing : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-
-	public void UpdateWhenNotified()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("References")]
 	public Transform orientation;
 	public Rigidbody rb;
@@ -70,14 +58,11 @@ public class Climbing : MonoBehaviour, IObserver
 		}
 	}
 
-	private void Start()
+	protected override void Start()
 	{
-		lg = GetComponent<LedgeGrabbing>();
+		base.Start();
 
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
-		}
+		lg = GetComponent<LedgeGrabbing>();
 	}
 
 	private void Update()

--- a/Assets/Movement/Dashing.cs
+++ b/Assets/Movement/Dashing.cs
@@ -2,8 +2,20 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Dashing : MonoBehaviour
+public class Dashing : MonoBehaviour, IObserver
 {
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
 	[Header("References")]
 	public Transform orientation;
 	public Transform playerCam;
@@ -54,7 +66,13 @@ public class Dashing : MonoBehaviour
 	{
 		rb = GetComponent<Rigidbody>();
 		pm = GetComponent<PlayerMovement>();
+
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
 	}
+
 	private void Update()
 	{
 		if (Input.GetKeyDown(dashKey))

--- a/Assets/Movement/Dashing.cs
+++ b/Assets/Movement/Dashing.cs
@@ -36,6 +36,20 @@ public class Dashing : MonoBehaviour
 	[Header("Input")]
 	public KeyCode dashKey = KeyCode.E;
 
+	private static Dashing instance;
+
+	public static Dashing Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new Dashing();
+			}
+			return instance;
+		}
+	}
+
 	private void Start()
 	{
 		rb = GetComponent<Rigidbody>();

--- a/Assets/Movement/Dashing.cs
+++ b/Assets/Movement/Dashing.cs
@@ -2,20 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Dashing : MonoBehaviour, IObserver
+public class Dashing : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-
-	public void UpdateWhenNotified()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("References")]
 	public Transform orientation;
 	public Transform playerCam;
@@ -62,15 +50,12 @@ public class Dashing : MonoBehaviour, IObserver
 		}
 	}
 
-	private void Start()
+	protected override void Start()
 	{
+		base.Start();
+
 		rb = GetComponent<Rigidbody>();
 		pm = GetComponent<PlayerMovement>();
-
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
-		}
 	}
 
 	private void Update()

--- a/Assets/Movement/Grappling.cs
+++ b/Assets/Movement/Grappling.cs
@@ -3,9 +3,21 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 
-public class Grappling : MonoBehaviour
+public class Grappling : MonoBehaviour, IObserver
 {
-    [Header("References")]
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
+	[Header("References")]
     private PlayerMovement pm;
     public Transform cam;
     public Transform gunTip;
@@ -52,7 +64,12 @@ public class Grappling : MonoBehaviour
     {
         pm = GetComponent<PlayerMovement>();
         lr.enabled = false;
-    }
+
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
+	}
 
     private void Update()
     {

--- a/Assets/Movement/Grappling.cs
+++ b/Assets/Movement/Grappling.cs
@@ -34,7 +34,21 @@ public class Grappling : MonoBehaviour
 
     private bool grappling;
 
-    private void Start()
+	private static Grappling instance;
+
+	public static Grappling Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new Grappling();
+			}
+			return instance;
+		}
+	}
+
+	private void Start()
     {
         pm = GetComponent<PlayerMovement>();
         lr.enabled = false;

--- a/Assets/Movement/Grappling.cs
+++ b/Assets/Movement/Grappling.cs
@@ -3,20 +3,8 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 
-public class Grappling : MonoBehaviour, IObserver
+public class Grappling : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-
-	public void UpdateWhenNotified()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("References")]
     private PlayerMovement pm;
     public Transform cam;
@@ -60,15 +48,12 @@ public class Grappling : MonoBehaviour, IObserver
 		}
 	}
 
-	private void Start()
+	protected override void Start()
     {
-        pm = GetComponent<PlayerMovement>();
-        lr.enabled = false;
+        base.Start();
 
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
-		}
+		pm = GetComponent<PlayerMovement>();
+        lr.enabled = false;
 	}
 
     private void Update()

--- a/Assets/Movement/LedgeGrabbing.cs
+++ b/Assets/Movement/LedgeGrabbing.cs
@@ -3,8 +3,20 @@ using System.Collections.Generic;
 using Unity.VisualScripting.Antlr3.Runtime.Tree;
 using UnityEngine;
 
-public class LedgeGrabbing : MonoBehaviour
+public class LedgeGrabbing : MonoBehaviour, IObserver
 {
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
 	[Header("References")]
 	public PlayerMovement pm;
 	public Transform orientation;
@@ -51,6 +63,14 @@ public class LedgeGrabbing : MonoBehaviour
 				instance = new LedgeGrabbing();
 			}
 			return instance;
+		}
+	}
+
+	private void Start()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
 		}
 	}
 

--- a/Assets/Movement/LedgeGrabbing.cs
+++ b/Assets/Movement/LedgeGrabbing.cs
@@ -40,6 +40,20 @@ public class LedgeGrabbing : MonoBehaviour
 	public float exitLedgeTime;
 	private float exitLedgeTimer;
 
+	private static LedgeGrabbing instance;
+
+	public static LedgeGrabbing Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new LedgeGrabbing();
+			}
+			return instance;
+		}
+	}
+
 	private void Update()
 	{
 		LedgeDetection();

--- a/Assets/Movement/LedgeGrabbing.cs
+++ b/Assets/Movement/LedgeGrabbing.cs
@@ -3,20 +3,8 @@ using System.Collections.Generic;
 using Unity.VisualScripting.Antlr3.Runtime.Tree;
 using UnityEngine;
 
-public class LedgeGrabbing : MonoBehaviour, IObserver
+public class LedgeGrabbing : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-
-	public void UpdateWhenNotified()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("References")]
 	public PlayerMovement pm;
 	public Transform orientation;
@@ -63,14 +51,6 @@ public class LedgeGrabbing : MonoBehaviour, IObserver
 				instance = new LedgeGrabbing();
 			}
 			return instance;
-		}
-	}
-
-	private void Start()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
 		}
 	}
 

--- a/Assets/Movement/PlayerMovement.cs
+++ b/Assets/Movement/PlayerMovement.cs
@@ -3,8 +3,20 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Experimental.GlobalIllumination;
 
-public class PlayerMovement : MonoBehaviour
+public class PlayerMovement : MonoBehaviour, IObserver
 {
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach(var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
 	[Header("Movement")]
 	private float moveSpeed;
 	public float walkSpeed;
@@ -126,6 +138,11 @@ public class PlayerMovement : MonoBehaviour
 		canJump = true;
 
 		startYScale = transform.localScale.y;
+
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
 	}
 
 	private void FixedUpdate()

--- a/Assets/Movement/PlayerMovement.cs
+++ b/Assets/Movement/PlayerMovement.cs
@@ -3,20 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Experimental.GlobalIllumination;
 
-public class PlayerMovement : MonoBehaviour, IObserver
+public class PlayerMovement : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-
-	public void UpdateWhenNotified()
-	{
-		foreach(var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("Movement")]
 	private float moveSpeed;
 	public float walkSpeed;
@@ -130,19 +118,16 @@ public class PlayerMovement : MonoBehaviour, IObserver
 		}
 	}
 
-	private void Start()
+	protected override void Start()
 	{
+		base.Start();
+
 		rb = GetComponent<Rigidbody>();
 		rb.freezeRotation = true;
 
 		canJump = true;
 
 		startYScale = transform.localScale.y;
-
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
-		}
 	}
 
 	private void FixedUpdate()

--- a/Assets/Movement/PlayerMovement.cs
+++ b/Assets/Movement/PlayerMovement.cs
@@ -104,6 +104,20 @@ public class PlayerMovement : MonoBehaviour
 		air
 	}
 
+	private static PlayerMovement instance;
+
+	public static PlayerMovement Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new PlayerMovement();
+			}
+			return instance;
+		}
+	}
+
 	private void Start()
 	{
 		rb = GetComponent<Rigidbody>();

--- a/Assets/Movement/Sliding.cs
+++ b/Assets/Movement/Sliding.cs
@@ -2,8 +2,19 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Sliding : MonoBehaviour
+public class Sliding : MonoBehaviour, IObserver
 {
+	[Header("Observer")]
+	public Win[] Observees;
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
 	[Header("References")]
 	public Transform orientation;
 	public Transform playerObj;
@@ -43,6 +54,11 @@ public class Sliding : MonoBehaviour
 		pm = GetComponent<PlayerMovement>();
 
 		startYScale = playerObj.localScale.y;
+
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
 	}
 
 	private void Update()

--- a/Assets/Movement/Sliding.cs
+++ b/Assets/Movement/Sliding.cs
@@ -2,19 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Sliding : MonoBehaviour, IObserver
+public class Sliding : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-	public void UpdateWhenNotified()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("References")]
 	public Transform orientation;
 	public Transform playerObj;
@@ -48,17 +37,14 @@ public class Sliding : MonoBehaviour, IObserver
 			return instance;
 		}
 	}
-	private void Start()
+	protected override void Start()
 	{
+		base.Start();
+
 		rb = GetComponent<Rigidbody>();
 		pm = GetComponent<PlayerMovement>();
 
 		startYScale = playerObj.localScale.y;
-
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
-		}
 	}
 
 	private void Update()

--- a/Assets/Movement/Sliding.cs
+++ b/Assets/Movement/Sliding.cs
@@ -24,6 +24,19 @@ public class Sliding : MonoBehaviour
 	private float horizontalInput;
 	private float verticalInput;
 
+	private static Sliding instance;
+
+	public static Sliding Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new Sliding();
+			}
+			return instance;
+		}
+	}
 	private void Start()
 	{
 		rb = GetComponent<Rigidbody>();

--- a/Assets/Movement/Swinging.cs
+++ b/Assets/Movement/Swinging.cs
@@ -1,19 +1,7 @@
 using UnityEngine;
 
-public class Swinging : MonoBehaviour, IObserver
+public class Swinging : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-
-	public void UpdateWhenNotified()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("References")]
 	public LineRenderer lr;
 	public Transform gunTip, cam, player;
@@ -74,14 +62,11 @@ public class Swinging : MonoBehaviour, IObserver
 		DrawRope();
 	}
 
-	private void Start()
+	protected override void Start()
 	{
-        lr.enabled = false;
+		base.Start();
 
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
-		}
+		lr.enabled = false;
 	}
 
 	private void StartSwing()

--- a/Assets/Movement/Swinging.cs
+++ b/Assets/Movement/Swinging.cs
@@ -29,8 +29,22 @@ public class Swinging : MonoBehaviour
 	[Header("Input")]
 	public KeyCode swingKey = KeyCode.Mouse0;
 
+	private static Swinging instance;
 
-    private void Update()
+	public static Swinging Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new Swinging();
+			}
+			return instance;
+		}
+	}
+
+
+	private void Update()
 	{
 		if(!PauseMenu.isPaused)
 		{

--- a/Assets/Movement/Swinging.cs
+++ b/Assets/Movement/Swinging.cs
@@ -1,7 +1,19 @@
 using UnityEngine;
 
-public class Swinging : MonoBehaviour
+public class Swinging : MonoBehaviour, IObserver
 {
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
 	[Header("References")]
 	public LineRenderer lr;
 	public Transform gunTip, cam, player;
@@ -65,6 +77,11 @@ public class Swinging : MonoBehaviour
 	private void Start()
 	{
         lr.enabled = false;
+
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
 	}
 
 	private void StartSwing()

--- a/Assets/Movement/WallRunning.cs
+++ b/Assets/Movement/WallRunning.cs
@@ -51,6 +51,20 @@ public class WallRunning : MonoBehaviour
 	private LedgeGrabbing lg;
 	private Rigidbody rb;
 
+	private static WallRunning instance;
+
+	public static WallRunning Instance
+	{
+		get
+		{
+			if (instance == null)
+			{
+				instance = new WallRunning();
+			}
+			return instance;
+		}
+	}
+
 	private void Start()
 	{
 		rb = GetComponent<Rigidbody>();

--- a/Assets/Movement/WallRunning.cs
+++ b/Assets/Movement/WallRunning.cs
@@ -3,20 +3,8 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using UnityEngine;
 
-public class WallRunning : MonoBehaviour, IObserver
+public class WallRunning : ObserverFlyweight
 {
-	[Header("Observer")]
-	public Win[] Observees;
-
-	public void UpdateWhenNotified()
-	{
-		foreach (var observee in Observees)
-		{
-			observee.Unsubscribe(this);
-		}
-		this.enabled = false;
-	}
-
 	[Header("WallRunning")]
 	public LayerMask isWall;
 	public LayerMask isGround;
@@ -77,16 +65,11 @@ public class WallRunning : MonoBehaviour, IObserver
 		}
 	}
 
-	private void Start()
+	protected override void Start()
 	{
 		rb = GetComponent<Rigidbody>();
 		pm = GetComponent<PlayerMovement>();
 		lg = GetComponent<LedgeGrabbing>();
-
-		foreach (var observee in Observees)
-		{
-			observee.Subscribe(this);
-		}
 	}
 
 	private void Update()

--- a/Assets/Movement/WallRunning.cs
+++ b/Assets/Movement/WallRunning.cs
@@ -3,8 +3,20 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using UnityEngine;
 
-public class WallRunning : MonoBehaviour
+public class WallRunning : MonoBehaviour, IObserver
 {
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
 	[Header("WallRunning")]
 	public LayerMask isWall;
 	public LayerMask isGround;
@@ -70,6 +82,11 @@ public class WallRunning : MonoBehaviour
 		rb = GetComponent<Rigidbody>();
 		pm = GetComponent<PlayerMovement>();
 		lg = GetComponent<LedgeGrabbing>();
+
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
 	}
 
 	private void Update()

--- a/Assets/Scenes/BetaGameIteration1.unity
+++ b/Assets/Scenes/BetaGameIteration1.unity
@@ -5851,6 +5851,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b29231b7d52cd2847bd4b0b29d9ba0ef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   pm: {fileID: 0}
   orientation: {fileID: 0}
   cam: {fileID: 0}
@@ -5881,6 +5886,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 438b3101b5fa0054eaf9671f37c9a28c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   orientation: {fileID: 0}
   rb: {fileID: 0}
   pm: {fileID: 0}
@@ -5911,6 +5921,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c7d913808d0c144ca21b035ba197ed1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   lr: {fileID: 1476913024}
   gunTip: {fileID: 2143809210}
   cam: {fileID: 851696555}
@@ -5939,6 +5954,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e692d2c6947e624a93a5da74e0f3fa4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   cam: {fileID: 851696555}
   gunTip: {fileID: 606812569}
   isGrappleable:
@@ -5964,6 +5984,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f6ed9c562fa1d64da0e9902c90154d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   orientation: {fileID: 780972901}
   playerCam: {fileID: 1548825913}
   dashForce: 20
@@ -5992,6 +6017,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 38bf288bf3e61ca44885691178f94c80, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   isWall:
     serializedVersion: 2
     m_Bits: 192
@@ -6027,6 +6057,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 69261f2fc6edfe84a9403a6052eae9db, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   orientation: {fileID: 780972901}
   playerObj: {fileID: 1103248595}
   modelTransform: {fileID: 372566156}
@@ -6046,6 +6081,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: afff9bc6530d06e41811b3e45dd1bb75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Observees:
+  - {fileID: 1089128821}
+  - {fileID: 139651821}
+  - {fileID: 254274203}
+  - {fileID: 464780543}
   walkSpeed: 7
   sprintSpeed: 10
   slideSpeed: 30

--- a/Assets/Scenes/BetaGameIterationVersion2.unity
+++ b/Assets/Scenes/BetaGameIterationVersion2.unity
@@ -5337,6 +5337,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b29231b7d52cd2847bd4b0b29d9ba0ef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 0}
   pm: {fileID: 0}
   orientation: {fileID: 0}
   cam: {fileID: 0}
@@ -5367,6 +5368,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 438b3101b5fa0054eaf9671f37c9a28c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 0}
   orientation: {fileID: 0}
   rb: {fileID: 0}
   pm: {fileID: 0}
@@ -5397,6 +5399,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c7d913808d0c144ca21b035ba197ed1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 0}
   lr: {fileID: 1476913024}
   gunTip: {fileID: 2143809210}
   cam: {fileID: 851696555}
@@ -5425,6 +5428,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e692d2c6947e624a93a5da74e0f3fa4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 0}
   cam: {fileID: 851696555}
   gunTip: {fileID: 606812569}
   isGrappleable:
@@ -5450,6 +5454,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f6ed9c562fa1d64da0e9902c90154d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 0}
   orientation: {fileID: 780972901}
   playerCam: {fileID: 1548825913}
   dashForce: 20
@@ -5478,6 +5483,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 38bf288bf3e61ca44885691178f94c80, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 0}
   isWall:
     serializedVersion: 2
     m_Bits: 192
@@ -5513,6 +5519,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 69261f2fc6edfe84a9403a6052eae9db, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 0}
   orientation: {fileID: 780972901}
   playerObj: {fileID: 1103248595}
   modelTransform: {fileID: 372566156}
@@ -5532,6 +5539,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: afff9bc6530d06e41811b3e45dd1bb75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  win: {fileID: 1089128821}
   walkSpeed: 7
   sprintSpeed: 10
   slideSpeed: 30

--- a/Assets/Scenes/BetaGameIterationVersion2.unity
+++ b/Assets/Scenes/BetaGameIterationVersion2.unity
@@ -4614,6 +4614,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d94fdb31e082bfb41850445329f800cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  lose: 0
 --- !u!1 &1103248592
 GameObject:
   m_ObjectHideFlags: 0
@@ -5610,7 +5611,7 @@ Transform:
   m_GameObject: {fileID: 1209586434}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 104, z: 21.2}
+  m_LocalPosition: {x: 0, y: 104, z: -3.81}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/Scripts/ObserveeFlyweight.cs
+++ b/Assets/Scripts/ObserveeFlyweight.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ObserverFlyweight : MonoBehaviour, IObserver
+{
+	[Header("Observer")]
+	public Win[] Observees;
+
+	public void UpdateWhenNotified()
+	{
+		foreach (var observee in Observees)
+		{
+			observee.Unsubscribe(this);
+		}
+		this.enabled = false;
+	}
+
+	// Start is called before the first frame update
+	protected virtual void Start()
+    {
+		foreach (var observee in Observees)
+		{
+			observee.Subscribe(this);
+		}
+	}
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/ObserveeFlyweight.cs.meta
+++ b/Assets/Scripts/ObserveeFlyweight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58538e10502288a458b9b7f2c754b0d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ObserverFlyweight.cs
+++ b/Assets/Scripts/ObserverFlyweight.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ObserveeFlyweight
+{
+	
+}

--- a/Assets/Scripts/ObserverFlyweight.cs.meta
+++ b/Assets/Scripts/ObserverFlyweight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80bfe9d576ab4b24289138de4f2e1ad0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Win.cs
+++ b/Assets/Win.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -5,11 +6,39 @@ using UnityEngine.SceneManagement;
 
 public class Win : MonoBehaviour
 {
-    [SerializeField] bool lose;
+	private List<IObserver> observers = new List<IObserver>();
+
+    public void Subscribe(IObserver observer) 
+    { 
+        observers.Add(observer); 
+    }
+
+    public void Unsubscribe(IObserver observer)
+    {
+        observers.Remove(observer);
+    }
+
+	public void Notify()
+	{
+		foreach (IObserver observer in observers)
+		{
+			observer.UpdateWhenNotified();
+		}
+	}
+
+	[SerializeField] bool lose;
     private void OnTriggerStay(Collider other)
     {
-        if (other.CompareTag("Player") && !lose) SceneManager.LoadScene("Win");
-        else if (other.CompareTag("Player")) SceneManager.LoadScene("GameOver");
+        if (other.CompareTag("Player") && !lose)
+        {
+            Notify();
+            SceneManager.LoadScene("Win");
+        }
+        else if (other.CompareTag("Player"))
+        {
+			Notify();
+            SceneManager.LoadScene("GameOver");
+		}
     }
 
 }


### PR DESCRIPTION
This was made because we only ever need to have one player that gets refenced and this way we can store all of these in just one instance.